### PR TITLE
Change expandData to selectHost for zabbix api 2.4 or above

### DIFF
--- a/jobs/zabbix.rb
+++ b/jobs/zabbix.rb
@@ -33,7 +33,7 @@ SCHEDULER.every '10s' do
       'selectItems' => 1,
       'withUnacknowledgedEvents' => 1,
       'skipDependent' => 1,
-      'expandData' => 'host'
+			'selectHosts' => 'extend'
     )
   end
 
@@ -44,8 +44,8 @@ SCHEDULER.every '10s' do
 
     list.push(res)
 
-    states[res['priority'].to_i].push(res['hostname'])
-    states[99].push(res['hostname'])
+    states[res['priority'].to_i].push(res['hosts'][0]['name'])
+    states[99].push(res['hosts'][0]['name'])
     # , Time.at(res["lastchange"].to_i), Time.now - 24.hours
   end
 

--- a/lib/trigger_list.rb
+++ b/lib/trigger_list.rb
@@ -23,7 +23,7 @@ class TriggerList
 
   def push_to_list(obj)
     h = {
-      host: obj['host'],
+      host: obj['hosts'][0]['name'],
       priority_code: obj['priority'].to_i,
       priority: @prios[obj['priority'].to_i],
       description: obj['description'],
@@ -41,7 +41,7 @@ class TriggerList
       priority_code: obj['priority'].to_i,
       priority: @prios[obj['priority'].to_i]
     }
-    @group_hosts[key].push(obj['host'])
+    @group_hosts[key].push(obj['hosts'][0]['name'])
   end
 
   def sorted_list


### PR DESCRIPTION
For Zabbix 2.4, some parameter of trigger get was changed and the expendData was removed. However we can use selectHost to get hostname instead.

Please help verify. 
